### PR TITLE
Recent perl6's now require "use v6" to appear before other statements

### DIFF
--- a/lib/StrictNamedArguments.pm
+++ b/lib/StrictNamedArguments.pm
@@ -1,5 +1,5 @@
-unit module StrictNamedArguments;
 use v6;
+unit module StrictNamedArguments;
 
 # First we need some exception to throw. Perl 6 kindly creates a
 # constructor for us that deals with filling all attributes with


### PR DESCRIPTION
In recent Perl6 builds, this module fails to install.  Example error when installing with zef:

```
===> Searching for: StrictNamedArguments
===> Testing: StrictNamedArguments:ver<0.1.0>
===SORRY!=== Error while compiling /data/home/jmaslak/.zef/store/StrictNamedArguments.git/351ff23434bd3f538723ce54ce6d663951bcde38/lib/StrictNamedArguments.pm (StrictNamedArguments)
Too late to switch language version. Must be used as the very first statement.
at /data/home/jmaslak/.zef/store/StrictNamedArguments.git/351ff23434bd3f538723ce54ce6d663951bcde38/lib/StrictNamedArguments.pm (StrictNamedArguments):2
------> use v6⏏;
===> Testing [FAIL]: StrictNamedArguments:ver<0.1.0>
Aborting due to test failure: StrictNamedArguments:ver<0.1.0> (use --force-test to override)
```

This fixes that issue.